### PR TITLE
add bg video support on mobile

### DIFF
--- a/main.js
+++ b/main.js
@@ -89,6 +89,8 @@ document.addEventListener('DOMContentLoaded', () => {
       backgroundElement.autoplay = true;
       backgroundElement.loop = true;
       backgroundElement.muted = true;
+      backgroundElement.playsinline = true; // Required for iOS
+      backgroundElement.setAttribute('webkit-playsinline', ''); // For older iOS versions
     } else {
       backgroundElement = document.createElement('img');
     }
@@ -110,6 +112,13 @@ document.addEventListener('DOMContentLoaded', () => {
     previewContainer.insertBefore(backgroundElement, previewContainer.firstChild);
     previewContainer.insertBefore(overlay, backgroundElement.nextSibling);
     previewContainer.appendChild(deleteBtn);
+
+    // Ensure video plays on mobile
+    if (backgroundElement instanceof HTMLVideoElement) {
+      backgroundElement.play().catch(error => {
+        console.error('Video autoplay failed:', error);
+      });
+    }
 
     hasBackground = true;
     status.textContent = 'background added';
@@ -228,7 +237,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       exportBtn.disabled = true;
-      status.textContent = 'generating video, please wait a moment...';
+      status.textContent = 'creating video, please wait a moment...';
 
       // Create canvas for video
       const canvas = document.createElement('canvas');


### PR DESCRIPTION
add `playsinline` to allow for autoplaying background videos

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/jessepimenta/dubplate.club/tree/add-background-video-support-on-mobile"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/jessepimenta/dubplate.club/tree/add-background-video-support-on-mobile)._