### PR TITLE
add border radius to preview container on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -332,6 +332,7 @@ input[type='file'] {
   .preview-container {
     max-height: 50vh;
     max-width: 50vh;
+    border-radius: 12px;
   }
 }
 


### PR DESCRIPTION

add border radius to preview container on mobile
<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/jessepimenta/dubplate.club/tree/add-border-radius-to-preview-container-on-mobile"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/jessepimenta/dubplate.club/tree/add-border-radius-to-preview-container-on-mobile)._